### PR TITLE
Allowing to force a specific network interface in DhcpClient mode

### DIFF
--- a/pydhcplib/dhcp_network.py
+++ b/pydhcplib/dhcp_network.py
@@ -207,9 +207,9 @@ class DhcpServer(DhcpNetwork) :
         self.BindToAddress()
 
 class DhcpClient(DhcpNetwork) :
-    def __init__(self, listen_address="0.0.0.0", client_listen_port=68,server_listen_port=67) :
+    def __init__(self, ifname=None, listen_address="0.0.0.0", client_listen_port=68,server_listen_port=67) :
         
-        DhcpNetwork.__init__(self,None,listen_address,client_listen_port,server_listen_port)
+        DhcpNetwork.__init__(self,ifname,listen_address,client_listen_port,server_listen_port)
 
         self.EnableBroadcast()
         self.EnableReuseaddr()


### PR DESCRIPTION
Hello, I have made a small change to allow specifying the ifname in the DhcpClient object constructor (the same way as it is already possible to do it in the DhcpServer object).
It highly makes sense to specify an network interface rather than an IP address in client mode (we are a DHCP client, so we don't have an IP address yet... we can only specify the interface).

Regards,

Lionel
